### PR TITLE
Added Payment types for current User

### DIFF
--- a/bangazonsite/initial_site/templates/initial_site/payment_list.html
+++ b/bangazonsite/initial_site/templates/initial_site/payment_list.html
@@ -1,0 +1,11 @@
+<h1>Payment Types</h1>
+	<ol>
+		
+			<h2>{{ user.first_name }} {{user.last_name}} </h2>
+		
+			{% for payment in payment_list %}
+		  	<li>
+		  		{{ payment.payment_type_name }}
+		  	</li>
+		{% endfor %}
+	</ol>

--- a/bangazonsite/initial_site/urls.py
+++ b/bangazonsite/initial_site/urls.py
@@ -15,5 +15,6 @@ urlpatterns += [
 
 # Payment Type Creation
 urlpatterns += [
-    url(r'^add_payment_type/$', views.add_payment_type, name="add_payment_type")
+    url(r'^add_payment_type/$', views.add_payment_type, name="add_payment_type"),
+    url(r'^list_payment_type/$', views.get_payment_type, name="get_payment_type")
 ]

--- a/bangazonsite/initial_site/views.py
+++ b/bangazonsite/initial_site/views.py
@@ -4,6 +4,7 @@ from django.views.generic.list import ListView
 from django.views.generic.base import TemplateView
 from django.views.generic.detail import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.decorators import login_required
 
 
 from . import models
@@ -45,6 +46,14 @@ def get_products_of_type(request, pk):
         'product_type': product_type[0]
     })
 
+@login_required
+def get_payment_type(request):
+    new_cust = models.Customer.objects.filter(user = request.user)
+    payments = models.PaymentType.objects.filter(customer = new_cust)
+    return render(request, 'initial_site/payment_list.html',{
+        'payment_list': payments,
+        'user': request.user
+    })
 
 def add_product(request):
     form = AddProductForm()
@@ -68,7 +77,9 @@ def add_payment_type(request):
 
         if form.is_valid():
             form.save(commit=True)
-            return HttpResponseRedirect(redirect_to='/')
+
+
+            return HttpResponseRedirect(redirect_to='/list_payment_type')
         else:
             print(form.errors)
     return render(request, 'initial_site/add_payment_type.html', {'form': form})


### PR DESCRIPTION
# Description
Added payment type filtered by active customer. Added new view for listing payment types. 
we can use this logic when we are selecting a payment  type to be used for an order.

# Related Ticket(s)
#28 

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[X] I certify that all existing tests pass

## Steps to Test
Outline the steps to test the code in this pull request.

1.  run server and navigate to /list_payment_types
NOTE: Must be signed in on registered user. This won't work until we have the ability to add a new user from the log in screen. pick a user name. Password is pass1234
